### PR TITLE
Pcp468

### DIFF
--- a/schema/brain/queries/writes.py
+++ b/schema/brain/queries/writes.py
@@ -99,6 +99,8 @@ def update_job_status(job_id, status, conn=None):
     if status not in VALID_STATES:
         raise ValueError("Invalid status")
     job_update = RBJ.get(job_id).update({"Status": status}).run(conn)
+    if job_update["replaced"] == 0 and job_update["unchanged"] == 0:
+        raise ValueError("".join(["Unknown Job", job_id]))
     id_filter = (r.row["OutputJob"]["id"] == job_id)
     output_job_status = {"OutputJob": {"Status": status}}
     output_update = RBO.filter(id_filter).update(output_job_status).run(conn)

--- a/schema/brain/queries/writes.py
+++ b/schema/brain/queries/writes.py
@@ -98,9 +98,9 @@ def update_job_status(job_id, status, conn=None):
     """
     if status not in VALID_STATES:
         raise ValueError("Invalid status")
-    job_update = RBJ.get(job_id).update({"Status": status}).run(conn)
+    job_update = RBJ.get(job_id).update({STATUS_FIELD: status}).run(conn)
     if job_update["replaced"] == 0 and job_update["unchanged"] == 0:
-        raise ValueError("".join(["Unknown Job", job_id]))
+        raise ValueError("Unknown job_id: {}".format(job_id))
     id_filter = (r.row["OutputJob"]["id"] == job_id)
     output_job_status = {"OutputJob": {"Status": status}}
     output_update = RBO.filter(id_filter).update(output_job_status).run(conn)

--- a/schema/brain/queries/writes.py
+++ b/schema/brain/queries/writes.py
@@ -94,7 +94,7 @@ def update_job_status(job_id, status, conn=None):
     :param status: <str> new status
     :param conn: <connection> a database connection (default: {None})
 
-    :return: <bool> whether job was updated successfully
+    :return: <dict> the update dicts for the job and the output
     """
     if status not in VALID_STATES:
         raise ValueError("Invalid status")

--- a/schema/test_queries.py
+++ b/schema/test_queries.py
@@ -354,6 +354,11 @@ def test_update_job_status(rethink):
     job_id = response["generated_keys"][0]
     queries.update_job_status(job_id, "Done", connect())
     assert queries.is_job_done(job_id, connect())
+    # test if updating with the same status does not raise exception
+    queries.update_job_status(job_id, "Done", connect())
+    assert queries.is_job_done(job_id, connect())
+    with raises(ValueError):
+        queries.update_job_status("sdffajnadfkjlnaldfkabdfha", "Done", connect())
 
 def test_write_output(rethink):
     response = queries.insert_jobs([TEST_JOB])

--- a/schema/test_queries.py
+++ b/schema/test_queries.py
@@ -357,8 +357,12 @@ def test_update_job_status(rethink):
     # test if updating with the same status does not raise exception
     queries.update_job_status(job_id, "Done", connect())
     assert queries.is_job_done(job_id, connect())
+
+
+def test_update_job_status_invalid_id(rethink):
     with raises(ValueError):
         queries.update_job_status("sdffajnadfkjlnaldfkabdfha", "Done", connect())
+
 
 def test_write_output(rethink):
     response = queries.insert_jobs([TEST_JOB])


### PR DESCRIPTION
update_job_status will raise an exception if updating a job fails to update due to an unknown id. if both replaced and unchanged are 0 it means there was not a job with that id. if a status is updated to the same status it had then there will be no exception since unchanged will not be 0. we do not want this check for output because when updating from ready to pending there will not yet be an output entry. output entries are created before setting a job to done